### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/DateTime/Math.pm6
+++ b/lib/DateTime/Math.pm6
@@ -1,4 +1,4 @@
-module DateTime::Math;
+unit module DateTime::Math;
 
 my subset DurationUnits of Str where -> $unit { $unit ~~ /^<[smhdwMy]>$/ }
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.