### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/math.t
+++ b/t/math.t
@@ -1,6 +1,6 @@
 use v6;
 
-BEGIN @*INC.push: 'lib';
+use lib 'lib';
 
 use Test;
 use DateTime::Math;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.