### PR TITLE
Infix gt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,18 @@ The math functions allowed are:
  * DateTime = DateTime + Seconds
  * DateTime = DateTime - Seconds
 
-And comparisons:
+~~And comparisons:~~
 
- * DateTime cmp DateTime
- * DateTime <=> DateTime
- * DateTime == DateTime
- * DateTime != DateTime
- * DateTime <= DateTime
- * DateTime < DateTime
- * DateTime >= DateTime
- * DateTime > DateTime
+~~* DateTime cmp DateTime~~
+~~* DateTime <=> DateTime~~
+~~* DateTime == DateTime~~
+~~* DateTime != DateTime~~
+~~* DateTime <= DateTime~~
+~~* DateTime < DateTime~~
+~~* DateTime >= DateTime~~
+~~* DateTime > DateTime~~
+
+Note: Rakudo has since implemented internal DateTime comparisons, therefore DateTime::Math's comparisons have been removed.
 
 Note that all of the math operations on DateTime objects are using the
 POSIX time, which is stored as seconds, so it does not support sub-second
@@ -45,6 +47,9 @@ math at this time.
 ## Author
 
  * [Timothy Totten](https://github.com/supernovus/)
+
+## Contributions by 
+ * [Clifton Wood](https://github.com/Xliff/)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,17 @@ The math functions allowed are:
  * DateTime = DateTime + Seconds
  * DateTime = DateTime - Seconds
 
-~~And comparisons:~~
+~~And comparisons:
 
-~~* DateTime cmp DateTime~~
-~~* DateTime <=> DateTime~~
-~~* DateTime == DateTime~~
-~~* DateTime != DateTime~~
-~~* DateTime <= DateTime~~
-~~* DateTime < DateTime~~
-~~* DateTime >= DateTime~~
-~~* DateTime > DateTime~~
+ * DateTime cmp DateTime
+ * DateTime <=> DateTime
+ * DateTime == DateTime
+ * DateTime != DateTime
+ * DateTime <= DateTime
+ * DateTime < DateTime
+ * DateTime >= DateTime
+ * DateTime > DateTime
+~~
 
 Note: Rakudo has since implemented internal DateTime comparisons, therefore DateTime::Math's comparisons have been removed.
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ The math functions allowed are:
 
 ~~And comparisons:~~
 
-~~* DateTime cmp DateTime~~
-~~* DateTime <=> DateTime~~
-~~* DateTime == DateTime~~
-~~* DateTime != DateTime~~
-~~* DateTime <= DateTime~~
-~~* DateTime < DateTime~~
-~~* DateTime >= DateTime~~
-~~* DateTime > DateTime~~
+ * ~~DateTime cmp DateTime~~
+ * ~~DateTime <=> DateTime~~
+ * ~~DateTime == DateTime~~
+ * ~~DateTime != DateTime~~
+ * ~~DateTime <= DateTime~~
+ * ~~DateTime < DateTime~~
+ * ~~DateTime >= DateTime~~
+ * ~~DateTime > DateTime~~
 
 Note: Rakudo has since implemented internal DateTime comparisons, therefore DateTime::Math's comparisons have been removed.
 

--- a/README.md
+++ b/README.md
@@ -27,17 +27,16 @@ The math functions allowed are:
  * DateTime = DateTime + Seconds
  * DateTime = DateTime - Seconds
 
-~~And comparisons:
+~~And comparisons:~~
 
- * DateTime cmp DateTime
- * DateTime <=> DateTime
- * DateTime == DateTime
- * DateTime != DateTime
- * DateTime <= DateTime
- * DateTime < DateTime
- * DateTime >= DateTime
- * DateTime > DateTime
-~~
+~~* DateTime cmp DateTime~~
+~~* DateTime <=> DateTime~~
+~~* DateTime == DateTime~~
+~~* DateTime != DateTime~~
+~~* DateTime <= DateTime~~
+~~* DateTime < DateTime~~
+~~* DateTime >= DateTime~~
+~~* DateTime > DateTime~~
 
 Note: Rakudo has since implemented internal DateTime comparisons, therefore DateTime::Math's comparisons have been removed.
 

--- a/lib/DateTime/Math.pm6
+++ b/lib/DateTime/Math.pm6
@@ -90,35 +90,37 @@ multi infix:<->(DateTime:D $a, DateTime:D $b) is export {
   $a.posix - $b.posix;
 }
 
-multi infix:<cmp>(DateTime $a, DateTime $b) is export {
-  $a.posix cmp $b.posix;
-}
 
-multi infix:«<=>»(DateTime $a, DateTime $b) is export {
-  $a.posix <=> $b.posix;
-}
-
-multi infix:<==>(DateTime $a, DateTime $b) is export {
-  $a.posix == $b.posix;
-}
-
-multi infix:<!=>(DateTime $a, DateTime $b) is export {
-  $a.posix != $b.posix;
-}
-
-multi infix:«<=»(DateTime $a, DateTime $b) is export {
-  $a.posix <= $b.posix;
-}
-
-multi infix:«<»(DateTime $a, DateTime $b) is export {
-  $a.posix < $b.posix;
-}
-
-multi infix:«>=»(DateTime $a, DateTime $b) is export {
-  $a.posix >= $b.posix;
-}
-
-multi infix:«>»(DateTime $a, DateTime $b) is export {
-  $a.posix > $b.posix;
-}
+# Now included in rakudo
+#multi infix:<cmp>(DateTime $a, DateTime $b) is export {
+#  $a.posix cmp $b.posix;
+#}
+#
+#multi infix:«<=>»(DateTime $a, DateTime $b) is export {
+#  $a.posix <=> $b.posix;
+#}
+#
+#multi infix:<==>(DateTime $a, DateTime $b) is export {
+#  $a.posix == $b.posix;
+#}
+#
+#multi infix:<!=>(DateTime $a, DateTime $b) is export {
+#  $a.posix != $b.posix;
+#}
+#
+#multi infix:«<=»(DateTime $a, DateTime $b) is export {
+#  $a.posix <= $b.posix;
+#}
+#
+#multi infix:«<»(DateTime $a, DateTime $b) is export {
+#  $a.posix < $b.posix;
+#}
+#
+#multi infix:«>=»(DateTime $a, DateTime $b) is export {
+#  $a.posix >= $b.posix;
+#}
+#
+#multi infix:«>»(DateTime $a, DateTime $b) is export {
+#  $a.posix > $b.posix;
+#}
 

--- a/t/math.t
+++ b/t/math.t
@@ -24,6 +24,9 @@ is $t2.day, 31, 'day changed correctly, subtract 1y';
 is $t1 - $t2, 31622400, 'DateTime - DateTime';
 is from-seconds($t1 - $t2, 'd'), 366, 'from-seconds to days';
 
+is duration-from-to(30, 'm', 'h'), 0.5, 'duration-to-from() works.';
+
+# These now test DateTime::Math created objects using rakudo's internal methods.
 ok $t1 > $t2, 'DateTime > DateTime';
 ok $t2 < $t1, 'DateTime < DateTime';
 ok $t1 >= $t2, 'DateTime >= DateTime';
@@ -32,6 +35,3 @@ ok !($t1 == $t2), 'DateTime == DateTime';
 is $t1 cmp $t2, 'More', 'DateTime cmp DateTime';
 is $t1 <=> $t2, 'More', 'DateTime <=> DateTime';
 ok $t1 != $t2, 'DateTime != DateTime';
-
-is duration-from-to(30, 'm', 'h'), 0.5, 'duration-to-from() works.';
-


### PR DESCRIPTION
This pull request removes the comparator operators from DateTime::Math, since they have now been internally implemented by Rakudo. 

The problem was discovered based on this error from the test suite.

==> Testing DateTime::Math
Ambiguous call to 'infix:«>»'; these signatures all match:
:(DateTime:D \a, DateTime:D \b)
:(DateTime $a, DateTime $b)
 in block <unit> at t/math.t line 27

Removing the comparators seemed the easiest solution. Now all test cases pass:

ok 1 - year changed correctly, add 1d
ok 2 - month changed correctly, add 1d
ok 3 - day changed correctly, add 1d
ok 4 - year changed correctly, subtract 1y
ok 5 - month changed correctly, subtract 1y
ok 6 - day changed correctly, subtract 1y
ok 7 - DateTime - DateTime
ok 8 - from-seconds to days
ok 9 - duration-to-from() works.
ok 10 - DateTime > DateTime
ok 11 - DateTime < DateTime
ok 12 - DateTime >= DateTime
ok 13 - DateTime <= DateTime
ok 14 - DateTime == DateTime
ok 15 - DateTime cmp DateTime
ok 16 - DateTime <=> DateTime
ok 17 - DateTime != DateTime