### PR TITLE
Return a Duration object for subtraction of two DateTime objects

### DIFF
--- a/lib/DateTime/Math.pm6
+++ b/lib/DateTime/Math.pm6
@@ -87,7 +87,7 @@ multi infix:«-»(DateTime:D $dt, Numeric:D $x) is export {
 }
 
 multi infix:<->(DateTime:D $a, DateTime:D $b) is export {
-  $a.posix - $b.posix;
+  Duration.new($a.posix - $b.posix);
 }
 
 


### PR DESCRIPTION
If you subtract two date times return a Duration of the seconds instead of just an Int this should in theory behave exactly the same for everyone involved but just be ready for any additional date functionality added to duration.